### PR TITLE
fix paraswap transactions request and QoL updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ For this initial version, **no binaries are provided**. You will need to **insta
 
 ## How to simulate
 
-You can use the `--dry-run` option to generate an example bundle without executing it. This option also displays the individual transactions involved. If you are using this tool to burn rETH, the transactions will always be printed. As that action is not time sensitive, take your time to confirm the transactions. They can be simulated using tools like [Tenderly](tenderly.co). 
+You can use the `--dry-run` option to generate an example bundle without executing it. This option also displays the individual transactions involved. If you are using this tool to burn rETH, the transactions will always be printed. As that action is not time sensitive, take your time to confirm the transactions. They can be simulated using tools like [Tenderly](https://tenderly.co/). 
 Since the transactions are sent as part of an MEV bundle, their execution depends on the state resulting from the previous transactions. Therefore, it is essential to update the chain state while simulating. Our primary focus is on the final transaction, as it executes the arbitrage.
 Below is an example of the `dry-run` option:
 ```

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ If you prefer not to run the CLI tool on your validator machine, you can execute
     - Use the `--node-private-key` flag to provide the private key for the node address used as the caller.
     - Example command:
     ```bash
-    ./distribute --rpc="your_rpc_url" --node-private-key="your_private_key" --minipools="0xABC123...,0xDEF456..."
+    ./distribute --rpc=your_rpc_url --node-private-key=your_private_key --minipools=0xABC123...,0xDEF456...
     ```
 
 By following these steps, you can safely run the CLI tool on an external machine, ensuring that your validator machine remains secure and isolated from potential risks associated with running additional software. While the tool has access to the node operator hot wallet, this address should not contain a lot of ETH. Therfor the risk is minimal. 
@@ -319,7 +319,7 @@ This CLI tool is configured primarily through command-line flags. Below is a lis
     - `paraswap` or `p`: Uses the Morpho as flash loan provider and Paraswap for the swapping.  
     **Example**:
     ```bash
-    ./distribute --protocol="uniswap"
+    ./distribute --protocol=uniswap
     ```
 
 ---
@@ -332,7 +332,7 @@ This CLI tool is configured primarily through command-line flags. Below is a lis
   **Description**: Single minipool address to distribute. Use this if you only want to distribute to one minipool at a time.  
   **Example**:
   ```bash
-  ./distribute --minipool="0xABC123..."
+  ./distribute --minipool=0xABC123...
   ```
 
 ---
@@ -345,7 +345,7 @@ This CLI tool is configured primarily through command-line flags. Below is a lis
   **Description**: Comma-separated list of minipool addresses to distribute. This does not reduce the gas fee per distribute, but only one arbitrage call is needed.
   **Example**:
   ```bash
-  ./distribute --minipools="0xABC123...,0xDEF456...,0x789ABC..."
+  ./distribute --minipools=0xABC123...,0xDEF456...,0x789ABC...
   ```
 
 ---
@@ -358,7 +358,7 @@ This CLI tool is configured primarily through command-line flags. Below is a lis
     **Description**: Specifies the receiver address for the arbitrage profits. If not set, the node address is used by default. This address will also receive any Flashbots gas refunds (if applicable) when no personal searcher key is used. If the `--receiver` flag is not provided, the withdrawal address of the node (specified by the `--node-address` flag) will be used.  
     **Example**:
     ```bash
-    ./distribute --receiver="0xYourReceiverAddress"
+    ./distribute --receiver=0xYourReceiverAddress
     ```
 
 ---
@@ -371,7 +371,7 @@ This CLI tool is configured primarily through command-line flags. Below is a lis
     **Description**: Specifies the node address used as the caller to sign the transactions. If not set, the first minipool's node address is used by default. This flag should only be needed in edge cases, use carefully.  
     **Example**:
     ```bash
-    ./distribute --node-address="0xYourNodeAddress"
+    ./distribute --node-address=0xYourNodeAddress
     ```
 
 ---
@@ -384,7 +384,7 @@ This CLI tool is configured primarily through command-line flags. Below is a lis
     **Description**: Specifies the private key for the node address used as the caller. This can be used if the script should not use the Rocket Pool daemon to sign transactions. For example, when using external services like Allnodes.
     **Example**:
     ```bash
-    ./distribute --node-private-key="your_private_key"
+    ./distribute --node-private-key=your_private_key
     ```
 
 ---
@@ -425,7 +425,7 @@ If you are not using the Rocket Pool smartnode Docker version, this flag allows 
   **Description**: **Completly optional!** Private key for the searcher used in Flashbots transactions. Flashbots uses a repupation based system to controll access in times of high demand. For more information: https://docs.flashbots.net/flashbots-auction/advanced/reputation 
   **Example**:
   ```bash
-  ./distribute --searcher-private-key="abcdef123456..."
+  ./distribute --searcher-private-key=abcdef123456...
   ```
 
 ---
@@ -438,7 +438,7 @@ If you are not using the Rocket Pool smartnode Docker version, this flag allows 
   **Description**: Usually, this is the Rocket Pool eth1 client. Alternatively, you can specify a different RPC endpoint if needed. Use `--rpc-port` if you only want to set a non-default port.
   **Example**:
   ```bash
-  ./distribute --rpc="https://mainnet.infura.io/v3/YOUR_PROJECT_ID"
+  ./distribute --rpc=https://mainnet.infura.io/v3/YOUR_PROJECT_ID
   ```
 
 Notice: When using a free RPC connection, consider setting a rate limit to avoid overloading the endpoint. Use the `--ratelimit` flag to control the number of calls per second, ensuring compliance with provider limits.
@@ -453,7 +453,7 @@ Notice: When using a free RPC connection, consider setting a rate limit to avoid
   **Description**: Use this flag if you are using a non-default port for the Rocket Pool eth1 client. Alternatively, you can use a different RPC endpoint with the `--rpc` flag.
   **Example**:
   ```bash
-  ./distribute --rpc-port="9545"
+  ./distribute --rpc-port=9545
   ```
 
 ---
@@ -528,7 +528,7 @@ Notice: When using a free RPC connection, consider setting a rate limit to avoid
 You can combine multiple flags in a single command. For example:
 
 ```bash
-./distribute --local-reth --minipools="0xABC123...,0xDEF456..." --debug
+./distribute --local-reth --minipools=0xABC123...,0xDEF456... --debug
 ```
 
 This example enables debug logs, uses local rETH and specifies multiple minipools.

--- a/arbitrage/buildCall.go
+++ b/arbitrage/buildCall.go
@@ -792,7 +792,7 @@ func fetchParaswapData(
 	respPrices, err := client.Do(reqPrices)
 	if err != nil {
 		return nil, errors.Join(errors.New("failed to send request"), err)
-	}	
+	}
 	defer respPrices.Body.Close()
 
 	if respPrices.StatusCode < http.StatusOK || respPrices.StatusCode >= http.StatusMultipleChoices {

--- a/arbitrage/buildCall.go
+++ b/arbitrage/buildCall.go
@@ -747,7 +747,14 @@ func useSmartnodeDaemon(logger *slog.Logger, apiCommand string, tx *types.Transa
 	return &signedTx, nil
 }
 
-func fetchParaswapData(ctx context.Context, logger *slog.Logger, amount *big.Int, senderAddress *common.Address, rEthContractAddress common.Address, networkId uint64) (*ParaswapArbitrage, error) {
+func fetchParaswapData(
+	ctx context.Context,
+	logger *slog.Logger,
+	amount *big.Int,
+	senderAddress *common.Address,
+	rEthContractAddress common.Address,
+	networkId uint64,
+) (*ParaswapArbitrage, error) {
 	WETHContractAddress, err := GetWETHContractAddress(networkId)
 	if err != nil {
 		return nil, errors.Join(errors.New("failed to get WETH contract address"), err)
@@ -785,6 +792,11 @@ func fetchParaswapData(ctx context.Context, logger *slog.Logger, amount *big.Int
 	respPrices, err := client.Do(reqPrices)
 	if err != nil {
 		return nil, errors.Join(errors.New("failed to send request"), err)
+	}	
+	defer respPrices.Body.Close()
+
+	if respPrices.StatusCode < http.StatusOK || respPrices.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("unexpected status code from prices API: %d", respPrices.StatusCode)
 	}
 
 	bodyPrices, err := io.ReadAll(respPrices.Body)
@@ -837,7 +849,7 @@ func fetchParaswapData(ctx context.Context, logger *slog.Logger, amount *big.Int
 	}
 
 	urlTransaction := fmt.Sprintf(
-		"https://api.paraswap.io/transactions/%d?onlyParams=true&ignoreChecks=true&ignoreGasEstimate=true",
+		"https://api.paraswap.io/transactions/%d?onlyParams=false&ignoreChecks=true&ignoreGasEstimate=true",
 		networkId,
 	)
 
@@ -869,6 +881,11 @@ func fetchParaswapData(ctx context.Context, logger *slog.Logger, amount *big.Int
 	respTransaction, err := client.Do(reqTransaction)
 	if err != nil {
 		return nil, errors.Join(errors.New("failed to send request"), err)
+	}
+	defer respTransaction.Body.Close()
+
+	if respTransaction.StatusCode < http.StatusOK || respTransaction.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("unexpected status code from transactions API: %d", respTransaction.StatusCode)
 	}
 
 	bodyTransaction, err := io.ReadAll(respTransaction.Body)

--- a/arbitrage/buildCall_test.go
+++ b/arbitrage/buildCall_test.go
@@ -28,9 +28,9 @@ func Test_fetchParaswapData(t *testing.T) {
 		wantErr bool
 	}{}
 
-	amounts := []int64{1, 1*24, 2*24, 3*24, 4*24, 5*24, 6*24, 7*24, 8*24, 9*24, 10*24}
+	amounts := []int64{1, 1 * 24, 2 * 24, 3 * 24, 4 * 24, 5 * 24, 6 * 24, 7 * 24, 8 * 24, 9 * 24, 10 * 24}
 	for _, amt := range amounts {
-		newTest :=struct {
+		newTest := struct {
 			name    string
 			args    args
 			want    *ParaswapArbitrage
@@ -47,7 +47,7 @@ func Test_fetchParaswapData(t *testing.T) {
 			},
 			want:    &ParaswapArbitrage{},
 			wantErr: false,
-		}	
+		}
 		tests = append(tests, newTest)
 	}
 	for _, tt := range tests {

--- a/arbitrage/buildCall_test.go
+++ b/arbitrage/buildCall_test.go
@@ -1,0 +1,71 @@
+package arbitrage
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func Test_fetchParaswapData(t *testing.T) {
+	// slog.SetLogLoggerLevel(slog.LevelDebug)
+	randomAddress := common.HexToAddress("0xfA82e08c42E6F62f95623F9ee8f2b15716F02aA6")
+	type args struct {
+		ctx                 context.Context
+		logger              *slog.Logger
+		amount              *big.Int
+		senderAddress       *common.Address
+		rEthContractAddress common.Address
+		networkId           uint64
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *ParaswapArbitrage
+		wantErr bool
+	}{}
+
+	amounts := []int64{1, 1*24, 2*24, 3*24, 4*24, 5*24, 6*24, 7*24, 8*24, 9*24, 10*24}
+	for _, amt := range amounts {
+		newTest :=struct {
+			name    string
+			args    args
+			want    *ParaswapArbitrage
+			wantErr bool
+		}{
+			name: fmt.Sprintf("Swap %d ETH", amt),
+			args: args{
+				ctx:                 context.Background(),
+				logger:              slog.Default(),
+				amount:              new(big.Int).Mul(big.NewInt(1e18), big.NewInt(amt)),
+				senderAddress:       &randomAddress,
+				rEthContractAddress: common.HexToAddress(Mainnet_rEthContractAddressStr),
+				networkId:           1,
+			},
+			want:    &ParaswapArbitrage{},
+			wantErr: false,
+		}	
+		tests = append(tests, newTest)
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := fetchParaswapData(tt.args.ctx, tt.args.logger, tt.args.amount, tt.args.senderAddress, tt.args.rEthContractAddress, tt.args.networkId)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("fetchParaswapData() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got.swapInAmountWeth.Cmp(big.NewInt(0)) == 0 {
+				t.Errorf("fetchParaswapData() swapInAmountWeth is zero")
+			}
+			if got.swapOutAmountReth.Cmp(big.NewInt(0)) == 0 {
+				t.Errorf("fetchParaswapData() swapOutAmountReth is zero")
+			}
+			if len(got.calldata) == 0 {
+				t.Errorf("fetchParaswapData() calldata is empty")
+			}
+		})
+	}
+}

--- a/arbitrage/executeDistribute.go
+++ b/arbitrage/executeDistribute.go
@@ -91,17 +91,9 @@ func ExecuteDistribute(ctx context.Context, logger *slog.Logger, dataIn *DataIn)
 	}
 
 	logger.Debug("created flashbots client")
-	res, success, err := dataIn.FbClient.SimulateBundle(bundle, 0)
+	success, bundleHash, arbTxHash, err := simulateBundle(logger, dataIn, bundle)
 	if err != nil {
 		return errors.Join(errors.New("failed to simulate bundle"), err)
-	}
-
-	// udpate success based on tx results
-	for index, tx := range res.Results {
-		if tx.Error != "" {
-			logger.Warn("tx failed", slog.Int("index", index), slog.String("error", tx.Error), slog.String("revertReason", hex.EncodeToString([]byte(tx.RevertReason))))
-			success = false
-		}
 	}
 
 	maxBundleFees, maxArbitrageFees := evalGasPrices(bundle)
@@ -197,7 +189,7 @@ func ExecuteDistribute(ctx context.Context, logger *slog.Logger, dataIn *DataIn)
 	}
 	bundle.SetTargetBlockNumber(blockNumber + 1)
 
-	fmt.Printf("\nSent bundle with hash: %s. Waiting for up to one minute to see if the transaction is included...\n\n", res.BundleHash)
+	fmt.Printf("\nSent bundle with hash: %s. Waiting for up to one minute to see if the transaction is included...\n\n", bundleHash)
 
 	timeoutContext, cancel := context.WithTimeout(ctx, time.Second*70)
 	successfullyIncluded, err := dataIn.FbClient.SendNBundleAndWait(timeoutContext, bundle, 4)
@@ -227,12 +219,10 @@ func ExecuteDistribute(ctx context.Context, logger *slog.Logger, dataIn *DataIn)
 	} else if dataIn.NetworkId == 17000 {
 		explorer = "https://explorer.holesky.io/tx/"
 	}
-	if len(res.Results) == 2 {
-		arbTx := res.Results[1]
-		fmt.Printf("Distributed minipool! %s tx: %s%s\n\n", txType, explorer, arbTx.TxHash.Hex())
+	if len(bundle.Transactions()) == 2 {
+		fmt.Printf("Distributed minipool! %s tx: %s%s\n\n", txType, explorer, arbTxHash.Hex())
 	} else {
-		arbTx := res.Results[len(res.Results)-1]
-		fmt.Printf("Distributed minipools! %s tx: %s%s\n\n", txType, explorer, arbTx.TxHash.Hex())
+		fmt.Printf("Distributed minipools! %s tx: %s%s\n\n", txType, explorer, arbTxHash.Hex())
 	}
 
 	return nil
@@ -302,4 +292,30 @@ func getWithdrawalAddress(ctx context.Context, client *ethclient.Client, network
 	}
 
 	return address, nil
+}
+
+func simulateBundle(logger *slog.Logger, dataIn *DataIn, bundle *flashbots_client.Bundle) (bool, common.Hash, common.Hash, error) {
+	simulationStateBlock, err := dataIn.Client.BlockNumber(context.Background())
+	if err != nil {
+		return false, common.Hash{}, common.Hash{}, errors.Join(errors.New("failed to get block number"), err)
+	}
+
+	res, success, err := dataIn.FbClient.SimulateBundle(bundle, simulationStateBlock)
+	// If there was an error and it's the special "header not found" error, try with simulationStateBlock-1.
+	if err != nil && strings.Contains(err.Error(), "header not found") {
+		logger.Debug("header not found, retrying", slog.Uint64("previous block", simulationStateBlock-1))
+		res, success, err = dataIn.FbClient.SimulateBundle(bundle, simulationStateBlock-1)
+	}
+	if err != nil {
+		return false, common.Hash{}, common.Hash{}, err
+	}
+
+	for index, tx := range res.Results {
+		if tx.Error != "" {
+			logger.Warn("tx failed", slog.Int("index", index), slog.String("error", tx.Error), slog.String("revertReason", hex.EncodeToString([]byte(tx.RevertReason))))
+			success = false
+		}
+	}
+
+	return success, common.Hash{}, common.Hash{}, nil
 }

--- a/cmd/distribute/distribute.go
+++ b/cmd/distribute/distribute.go
@@ -84,20 +84,21 @@ func parseInput(ctx context.Context, logger *slog.Logger) (data *arbitrage.DataI
 
 	data.MinipoolAddresses = []common.Address{}
 	if *minipoolFlag != "" {
-		if !common.IsHexAddress(*minipoolFlag) {
-			return nil, errors.New("minipool address is invalid")
+		minipoolStr := strings.Trim(*minipoolFlag, " \"'")
+		if !common.IsHexAddress(minipoolStr) {
+			return nil, fmt.Errorf("minipool address _%s_ is invalid", minipoolStr)
 		}
 
-		data.MinipoolAddresses = append(data.MinipoolAddresses, common.HexToAddress(*minipoolFlag))
-		logger.Debug("minipool", slog.String("minipool", common.HexToAddress(*minipoolFlag).Hex()))
+		data.MinipoolAddresses = append(data.MinipoolAddresses, common.HexToAddress(minipoolStr))
+		logger.Debug("minipool", slog.String("minipool", common.HexToAddress(minipoolStr).Hex()))
 	}
 
 	if *minipoolsFlag != "" {
 		minipools := strings.Split(*minipoolsFlag, ",")
 		for _, minipool := range minipools {
-			minipool = strings.TrimSpace(minipool) // handle whitespace
+			minipool = strings.Trim(minipool, " \"'")
 			if !common.IsHexAddress(minipool) {
-				return nil, fmt.Errorf("minipool address %s is invalid", minipool)
+				return nil, fmt.Errorf("minipool address _%s_ is invalid", minipool)
 			}
 
 			data.MinipoolAddresses = append(data.MinipoolAddresses, common.HexToAddress(minipool))


### PR DESCRIPTION
- The fetchParaswapData function reverts as it can not parse the response of the /transactions API (anymore?). This PR fixes the issue by setting `onlyParams=false`. It also adds a simple unit test for that function.

- Fixes a small bug where the "flags" package does not correctly trim spaces on every OS and streamlines the README to only use quotes where needed.

- QoL: Retry simulation if relay state is not updated yet

- QoL: best-effort revert reason parsing

