### PR TITLE
feat: Add profit threshold monitoring with per-minipool calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ When **exiting minipools** or **claiming ETH**, it is vital to check for arbitra
 
 The core objective is to leverage **distribute** calls in combination with **rETH burn** to capture potential arbitrage gains. This tool can also facilitate a **flashloan** for users who don't already hold rETH but want to capitalize on the arbitrage.
 
+**Profit Threshold Monitoring**: The tool now supports waiting for optimal arbitrage conditions using the `--threshold` flag. When set, the tool will continuously monitor the expected profit and only execute the arbitrage transaction when the profit meets or exceeds your specified threshold. This allows you to wait for more favorable market conditions before executing.
+
 If you prefer not to run this CLI tool on your validator machine alongside the smartnode daemon—or if you don't have access to the smartnode (for example, when using a service like [Allnodes](https://www.allnodes.com/)) — you can use the `--rpc=...` flag and provide your node operator private key via `--node-private-key`. You can also use your Withdrawal Address instead, depending on what best suits your situation.
 
 If you encounter any issues while using the tool, please open a GitHub issue so we can investigate and address it.
@@ -521,6 +523,24 @@ Notice: When using a free RPC connection, consider setting a rate limit to avoid
   ./distribute --ratelimit=250
   ```
 
+- **Flag**: `--threshold`
+  **Type**: float64  (ETH amount)
+  **Default**: `0`  
+  **Description**: Minimum profit threshold in ETH. If set, the tool will monitor profit and wait until the threshold is met before executing the arbitrage transaction. When set to 0, the tool executes immediately without monitoring.
+  **Example**: Wait until expected profit reaches 0.01 ETH before executing.
+  ```bash
+  ./distribute --threshold=0.01 --minipools=0xABC123...
+  ```
+
+- **Flag**: `--monitor-interval`
+  **Type**: int  (seconds)
+  **Default**: `60`  
+  **Description**: Interval in seconds to check profit when using `--threshold`. This controls how frequently the tool recalculates the expected profit to compare against the threshold.
+  **Example**: Check profit every 30 seconds.
+  ```bash
+  ./distribute --threshold=0.01 --monitor-interval=30 --minipools=0xABC123...
+  ```
+
 ---
 
 ## Combining Flags
@@ -532,6 +552,14 @@ You can combine multiple flags in a single command. For example:
 ```
 
 This example enables debug logs, uses local rETH and specifies multiple minipools.
+
+For profit threshold monitoring:
+
+```bash
+./distribute --threshold=0.02 --monitor-interval=30 --minipools=0xABC123...,0xDEF456... --skip-confirmation
+```
+
+This example waits until the expected profit reaches 0.02 ETH, checking every 30 seconds, and automatically executes without user confirmation once the threshold is met.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -524,10 +524,10 @@ Notice: When using a free RPC connection, consider setting a rate limit to avoid
   ```
 
 - **Flag**: `--threshold`
-  **Type**: float64  (ETH amount)
+  **Type**: float64  (ETH amount per minipool)
   **Default**: `0`  
-  **Description**: Minimum profit threshold in ETH. If set, the tool will monitor profit and wait until the threshold is met before executing the arbitrage transaction. When set to 0, the tool executes immediately without monitoring.
-  **Example**: Wait until expected profit reaches 0.01 ETH before executing.
+  **Description**: Minimum profit threshold in ETH per minipool. If set, the tool will monitor profit and wait until the per-minipool profit meets the threshold before executing the arbitrage transaction. When set to 0, the tool executes immediately without monitoring.
+  **Example**: Wait until expected profit reaches 0.01 ETH per minipool before executing.
   ```bash
   ./distribute --threshold=0.01 --minipools=0xABC123...
   ```
@@ -559,7 +559,7 @@ For profit threshold monitoring:
 ./distribute --threshold=0.02 --monitor-interval=30 --minipools=0xABC123...,0xDEF456... --skip-confirmation
 ```
 
-This example waits until the expected profit reaches 0.02 ETH, checking every 30 seconds, and automatically executes without user confirmation once the threshold is met.
+This example waits until the expected profit reaches 0.02 ETH per minipool (0.04 ETH total for 2 minipools), checking every 30 seconds, and automatically executes without user confirmation once the threshold is met.
 
 ---
 

--- a/arbitrage/types.go
+++ b/arbitrage/types.go
@@ -36,6 +36,8 @@ type DataIn struct {
 	Ratelimit                       int
 	Protocol                        Protocol
 	NetworkId                       uint64
+	Threshold                       float64
+	MonitorInterval                 int
 }
 
 type UniswapArbitrage struct {

--- a/cmd/distribute/distribute.go
+++ b/cmd/distribute/distribute.go
@@ -66,7 +66,7 @@ func parseInput(ctx context.Context, logger *slog.Logger) (data *arbitrage.DataI
 		"Private key for the node address used as caller. This can be used if the script should not use the RP daemon to sign transactions. (e.g. when using Allnode)",
 	)
 	ratelimitFlag := flag.Int("ratelimit", 0, "Rate limit in milliseconds between each minipool distribution call. (default: 0)")
-	thresholdFlag := flag.Float64("threshold", 0, "Minimum profit threshold in ETH. If set, the tool will monitor profit and wait until threshold is met before executing. (default: 0 - execute immediately)")
+	thresholdFlag := flag.Float64("threshold", 0, "Minimum profit threshold in ETH per minipool. If set, the tool will monitor profit and wait until per-minipool threshold is met before executing. (default: 0 - execute immediately)")
 	monitorIntervalFlag := flag.Int("monitor-interval", 60, "Interval in seconds to check profit when using --threshold. (default: 60 seconds)")
 
 	flag.Parse()

--- a/cmd/distribute/distribute.go
+++ b/cmd/distribute/distribute.go
@@ -66,6 +66,8 @@ func parseInput(ctx context.Context, logger *slog.Logger) (data *arbitrage.DataI
 		"Private key for the node address used as caller. This can be used if the script should not use the RP daemon to sign transactions. (e.g. when using Allnode)",
 	)
 	ratelimitFlag := flag.Int("ratelimit", 0, "Rate limit in milliseconds between each minipool distribution call. (default: 0)")
+	thresholdFlag := flag.Float64("threshold", 0, "Minimum profit threshold in ETH. If set, the tool will monitor profit and wait until threshold is met before executing. (default: 0 - execute immediately)")
+	monitorIntervalFlag := flag.Int("monitor-interval", 60, "Interval in seconds to check profit when using --threshold. (default: 60 seconds)")
 
 	flag.Parse()
 
@@ -241,6 +243,11 @@ func parseInput(ctx context.Context, logger *slog.Logger) (data *arbitrage.DataI
 
 	data.Ratelimit = *ratelimitFlag
 	logger.Debug("ratelimit", slog.Int("ratelimit", data.Ratelimit))
+
+	data.Threshold = *thresholdFlag
+	data.MonitorInterval = *monitorIntervalFlag
+	logger.Debug("threshold", slog.Float64("threshold", data.Threshold))
+	logger.Debug("monitorInterval", slog.Int("monitorInterval", data.MonitorInterval))
 
 	return data, nil
 }


### PR DESCRIPTION
# Add Profit Threshold Monitoring with Per-Minipool Calculation

## Overview
This MR introduces profit threshold monitoring functionality to the `./distribute` command, allowing users to wait for optimal arbitrage conditions before executing transactions. The threshold is calculated and applied on a per-minipool basis for consistent scaling across different numbers of minipools.

## Features Added

### 🎯 **Threshold Monitoring**
- New `--threshold` flag accepts minimum profit threshold in ETH per minipool
- New `--monitor-interval` flag controls monitoring frequency (default: 60 seconds)
- Continuous monitoring loop that waits until profit conditions are met
- Graceful interruption with Ctrl+C

### 📊 **Enhanced Profit Calculation**
- **Per-minipool profit calculation**: Threshold applies consistently regardless of minipool count
- **Total vs per-minipool display**: Shows both total profit and per-minipool breakdown
- **Real-time profit simulation**: Uses existing arbitrage simulation without execution
- **Fee-aware calculations**: Accounts for both bundle and arbitrage fees

### 📈 **Market Information Display**
- **rETH discount tracking**: Shows current rETH protocol exchange rate and discount percentage
- **Market context**: Helps users understand arbitrage opportunities
- **Error resilience**: Continues monitoring even if rETH info is temporarily unavailable

### 🔍 **Enhanced Logging**
- **Structured logging**: Detailed debug information with slog
- **Profit breakdown**: Logs total profit, per-minipool profit, threshold, and minipool count
- **Market data**: Logs rETH protocol rate and discount information
- **Timestamped output**: Clear monitoring progress with timestamps

## Implementation Details

### New Functions Added
1. **`CalculateExpectedProfit`**: Simulates arbitrage without execution to get profit estimates
2. **`getRETHDiscountInfo`**: Fetches rETH exchange rate and calculates discount percentage  
3. **`MonitorProfitUntilThreshold`**: Main monitoring loop with enhanced logging and display

### Modified Functions
- **`ExecuteDistribute`**: Added conditional threshold monitoring before execution
- **`parseInput`**: Added parsing for new threshold and monitor-interval flags

### New Fields in DataIn Struct
```go
Threshold       float64  // Profit threshold per minipool in ETH
MonitorInterval int      // Monitoring interval in seconds
```

## Usage Examples

### Basic threshold monitoring
```bash
./distribute --threshold=0.01 --minipools=0xABC123...
```

### Custom monitoring interval
```bash
./distribute --threshold=0.02 --monitor-interval=30 --minipools=0xABC123...,0xDEF456...
```

### Auto-execute when threshold met
```bash
./distribute --threshold=0.015 --skip-confirmation --minipools=0xABC123...
```

## Sample Output
```
2025/08/07 04:10:34 INFO Profit calculation module=distribute totalProfit=0.19349220302538545 profitPerMinipool=0.09674610151269272 thresholdPerMinipool=5 minipoolCount=2
2025/08/07 04:10:34 INFO rETH discount info module=distribute protocolRate=1.1428393877729024 discount=-14.283938777290238
[04:10:34] Total profit: 0.193492 ETH (0.096746 per minipool) | Threshold: 5.000000 per minipool | rETH rate: 1.142839 (-14.28% discount)
```


## Backward Compatibility
- **Fully backward compatible**: When `--threshold` is not set or is 0, behavior is unchanged
- **Existing flags unchanged**: All existing functionality remains intact
- **No breaking changes**: Existing scripts and workflows continue to work

## Files Modified

### Core Implementation
- `arbitrage/executeDistribute.go`: Added monitoring functions and enhanced logging
- `arbitrage/types.go`: Added Threshold and MonitorInterval fields to DataIn struct
- `cmd/distribute/distribute.go`: Added new flag parsing

### Documentation
- `README.md`: Updated with new flag documentation and examples

## Testing
- ✅ Builds successfully with `go build ./cmd/distribute/`
- ✅ Help text displays correctly with new flags
- ✅ Backward compatibility maintained (no threshold = immediate execution)
- ✅ SSH authentication configured for repository

## Benefits
1. **Optimal timing**: Wait for favorable market conditions before executing
2. **Scalable thresholds**: Per-minipool calculation works consistently across different minipool counts  
3. **Market awareness**: Real-time rETH discount information helps inform decisions
4. **User-friendly**: Clear progress indication and graceful interruption
5. **Risk management**: Avoid executing during unfavorable market conditions

## Configuration Help
```bash
./distribute --help
```

New flags:
- `--threshold float`: Minimum profit threshold in ETH per minipool (default: 0)
- `--monitor-interval int`: Interval in seconds to check profit when using --threshold (default: 60)